### PR TITLE
:wrench: Update Play Services framework tag to work with phonegap-plugin-push

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,83 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        id="cordova-admob-sdklibs"
-        version="2.1.4">
-      
+<plugin 
+    xmlns="http://apache.org/cordova/ns/plugins/1.0" 
+    xmlns:android="http://schemas.android.com/apk/res/android" id="cordova-admob-sdklibs" version="2.1.4">
     <name>Google Mobile Ads SDK for Cordova</name>
     <description>Add Google Mobile Ads SDK to Cordova project, as dependency for other plugins</description>
     <author>Google</author>
     <keywords>admob,google,ad</keywords>
     <repo>https://github.com/sunnycupertino/cordova-admob-sdklibs.gitt</repo>
     <issue>https://github.com/sunnycupertino/cordova-admob-sdklibs/issues</issue>
-
     <engines>
         <engine name="cordova" version=">=3.0" />
+        <engine name="cordova-android" version=">=6.3.0"/>
     </engines>
-
     <platform name="android">
         <!-- for gradle -->
-        <framework src="com.google.android.gms:play-services-base:+" />
-        <framework src="com.google.android.gms:play-services-ads:+" />
+        <preference name="PLAY_SERVICES_VERSION" default="11.0.1"/>
+        <framework src="com.google.android.gms:play-services-base:$PLAY_SERVICES_VERSION" />
+        <framework src="com.google.android.gms:play-services-ads:$PLAY_SERVICES_VERSION" />
         <!-- for ant -->
         <!--dependency id="cordova-plugin-googleplayservices"/ -->
-     </platform>
-    
+    </platform>
     <platform name="amazon-fireos">
         <!-- using ant, framework tag for android sdk cannot be supported, so we use external dependency -->
         <dependency id="cordova-plugin-googleplayservices"/>
-     </platform>
-
-     <platform name="ios">
-        <framework src="src/ios/GoogleMobileAds.framework" custom="true" />		
-		  <framework src="AdSupport.framework" />
-		  <framework src="AudioToolbox.framework" />
-		  <framework src="AVFoundation.framework" />
-		  <framework src="CoreGraphics.framework" />
-		  <framework src="CoreMedia.framework" />
-		  <framework src="CoreTelephony.framework" />
-		  <framework src="EventKit.framework" />
-		  <framework src="EventKitUI.framework" />
-		  <framework src="Foundation.framework" />
-		  <framework src="MediaPlayer.framework" />
-		  <framework src="MessageUI.framework" />
-		  <framework src="StoreKit.framework" />
-		  <framework src="SystemConfiguration.framework" />
-		  <framework src="UIKit.framework" />
-		  <framework src="QuartzCore.framework" />
-
-<!--
-		<hook type="after_plugin_add" src="hooks/after_plugin_add/000-create-links.sh" />
---> 
     </platform>
-
-     <!-- Windows Phone 8 -->
-     <platform name="wp8">
-          <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
-			<Capability Name="ID_CAP_IDENTITY_USER" />
-			<Capability Name="ID_CAP_NETWORKING" />
-			<Capability Name="ID_CAP_WEBBROWSERCOMPONENT" />
-			<Capability Name="ID_CAP_PHONEDIALER" />
-			<Capability Name="ID_CAP_MEDIALIB_PHOTO" />
+    <platform name="ios">
+        <framework src="src/ios/GoogleMobileAds.framework" custom="true" />
+        <framework src="AdSupport.framework" />
+        <framework src="AudioToolbox.framework" />
+        <framework src="AVFoundation.framework" />
+        <framework src="CoreGraphics.framework" />
+        <framework src="CoreMedia.framework" />
+        <framework src="CoreTelephony.framework" />
+        <framework src="EventKit.framework" />
+        <framework src="EventKitUI.framework" />
+        <framework src="Foundation.framework" />
+        <framework src="MediaPlayer.framework" />
+        <framework src="MessageUI.framework" />
+        <framework src="StoreKit.framework" />
+        <framework src="SystemConfiguration.framework" />
+        <framework src="UIKit.framework" />
+        <framework src="QuartzCore.framework" />
+        <!--
+		<hook type="after_plugin_add" src="hooks/after_plugin_add/000-create-links.sh" />
+-->
+    </platform>
+    <!-- Windows Phone 8 -->
+    <platform name="wp8">
+        <config-file target="Properties/WMAppManifest.xml" parent="/Deployment/App/Capabilities">
+            <Capability Name="ID_CAP_IDENTITY_USER" />
+            <Capability Name="ID_CAP_NETWORKING" />
+            <Capability Name="ID_CAP_WEBBROWSERCOMPONENT" />
+            <Capability Name="ID_CAP_PHONEDIALER" />
+            <Capability Name="ID_CAP_MEDIALIB_PHOTO" />
         </config-file>
-		
-		<framework src="src/wp8/GoogleAds.dll" custom="true" />
-     </platform>
-
-     <!-- Windows Phone 8.1+ -->
-     <platform name="windows">
+        <framework src="src/wp8/GoogleAds.dll" custom="true" />
+    </platform>
+    <!-- Windows Phone 8.1+ -->
+    <platform name="windows">
         <config-file target="package.windows.appxmanifest" parent="/Package/Capabilities">
-		    <Capability Name="internetClientServer" />
+            <Capability Name="internetClientServer" />
         </config-file>
         <config-file target="package.windows80.appxmanifest" parent="/Package/Capabilities">
-		    <Capability Name="internetClientServer" />
+            <Capability Name="internetClientServer" />
         </config-file>
         <config-file target="package.phone.appxmanifest" parent="/Package/Capabilities">
-		    <Capability Name="internetClientServer" />
+            <Capability Name="internetClientServer" />
         </config-file>
-	
-		<framework src="src/wp8/GoogleAds.dll" custom="true" />
+        <framework src="src/wp8/GoogleAds.dll" custom="true" />
     </platform>
-
 </plugin>


### PR DESCRIPTION
This change works around an incompatibility with Play Services and phonegap-plugin-push. Folks can still over-ride the Play Services version using a preference/variable but if you leave it as + that causes issues with the Google Services Gradle Plugin.

Sorry about the formatting changes. A combination of Prettier, eslint, VS Code auto styling.